### PR TITLE
Fix: 충돌 해결 이후 useSelector import 에러 fix

### DIFF
--- a/src/components/PDFViewer.js
+++ b/src/components/PDFViewer.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import * as pdfjs from "pdfjs-dist";
 import axios from "axios";
 


### PR DESCRIPTION
### 충돌 이후 useSelector import 에러 해결

### Description

- 충돌 해결 후 useSelector의 import가 사라진 내역 복원

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

### 스크린샷
