### PR TITLE
Fix: 모바일 기기 접속 차단.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
 <head>
   <title>PDF Editor, Noted!</title>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" type="image⁄x-icon"
     href="https://d1fdloi71mui9q.cloudfront.net/m1orKCmNRoWT4wuwOP6A_tmlS24Pb11vBb9h2">
 </head>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -112,6 +112,10 @@ const NavButton = styled.button`
   &:active {
     color: #ffc0cb;
   }
+
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
 `;
 
 const UserProfile = styled.img`

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -55,6 +55,12 @@ export default function Login() {
   return (
     <Wrapper>
       <BackgoundColorPage />
+      <MobileTitle>Sorry,</MobileTitle>
+      <MobileText>
+        We do not support mobile service.
+        <br />
+        please try on PC or laptop.
+      </MobileText>
       <MainImage src={pdfImage} alt="Main Page" />
       <FirstLineTitle>Find your creativity by</FirstLineTitle>
       <SecondLineTitle>pdf editor, Noted</SecondLineTitle>
@@ -83,6 +89,12 @@ const FirstLineTitle = styled.div`
   top: 30%;
   left: 45%;
   font-size: 400%;
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
+  @media screen and (max-width: 1200px) {
+    font-size: 5vw;
+  }
 `;
 
 const SecondLineTitle = styled.div`
@@ -90,14 +102,20 @@ const SecondLineTitle = styled.div`
   top: 41%;
   left: 60%;
   font-size: 400%;
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
+  @media screen and (max-width: 1200px) {
+    font-size: 5vw;
+  }
 `;
 
 const MainImage = styled.img`
   position: absolute;
   left: 5%;
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
 `;
 
 const LoginButton = styled.div`
@@ -112,5 +130,38 @@ const LoginButton = styled.div`
 
   &:active {
     color: #ffc0cb;
+  }
+
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
+  @media screen and (max-width: 1200px) {
+    font-size: 2.5vw;
+  }
+`;
+
+const MobileTitle = styled.p`
+  position: absolute;
+  top: 15%;
+  left: 10%;
+  z-index: 1;
+  font-size: 40px;
+  font-weight: 800;
+  display: none;
+  @media screen and (max-width: 768px) {
+    display: block;
+  }
+`;
+
+const MobileText = styled.p`
+  position: absolute;
+  top: 30%;
+  left: 10%;
+  z-index: 1;
+  font-size: 18px;
+  font-weight: 800;
+  display: none;
+  @media screen and (max-width: 768px) {
+    display: block;
   }
 `;


### PR DESCRIPTION

### Description

- 프로젝트에서 지원하지 않는 뷰포트 크기의 기기에서 접속 시, 브라우저 로그인 요청
- 로그인 페이지에 간단한 반응형 웹 구현

### Point

- 스타일드 컴포넌트에 미디어 쿼리를 사용했습니다.
- 로그인 페이지 타이틀의 행간이 어긋나는 1200px 부터는 폰트의 크기가 vw기준으로 변경되도록 했습니다.
- 태블릿의 분기점인 768px부터는 로그인 기능을 막고, 브라우저 로그인을 요청하는 메시지가 렌더링 됩니다. 

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull했습니다.
- [x] base 브랜치명을 확인했습니다.(Front, Backend, feature ...)
- [x] 코드 컨벤션을 모두 지켰습니다.
- [x] 적절한 라벨이 있습니다.
- [x] assignee가 있습니다.

### 스크린샷
![image](https://github.com/Thinking-in-human/Noted-client/assets/106131005/13505b2a-4ee9-41b2-9970-d5f02989ae62)
